### PR TITLE
Fix uploaded images display and delete images based on unique name

### DIFF
--- a/app/Logic/Image/ImageRepository.php
+++ b/app/Logic/Image/ImageRepository.php
@@ -57,7 +57,8 @@ class ImageRepository
 
         return Response::json([
             'error' => false,
-            'code'  => 200
+            'code'  => 200,
+            'filename' => $allowed_filename
         ], 200);
 
     }
@@ -103,15 +104,15 @@ class ImageRepository
     }
 
     /**
-     * Delete Image From Session folder, based on original filename
+     * Delete Image From Session folder, based on server created filename
      */
-    public function delete( $originalFilename)
+    public function delete( $filename )
     {
 
         $full_size_dir = Config::get('images.full_size');
         $icon_size_dir = Config::get('images.icon_size');
 
-        $sessionImage = Image::where('original_name', 'like', $originalFilename)->first();
+        $sessionImage = Image::where('filename', 'like', $filename)->first();
 
 
         if(empty($sessionImage))

--- a/public/assets/js/dropzone-config-2.js
+++ b/public/assets/js/dropzone-config-2.js
@@ -22,7 +22,7 @@ Dropzone.options.realDropzone = {
 
                 var file = {name: value.original, size: value.size};
                 myDropzone.options.addedfile.call(myDropzone, file);
-    			myDropzone.createThumbnailFromUrl(file, 'images/icon_size/' + value.server);
+                myDropzone.createThumbnailFromUrl(file, 'images/icon_size/' + value.server);
                 myDropzone.emit("complete", file);
                 photo_counter++;
                 $("#photoCounter").text( "(" + photo_counter + ")");

--- a/public/assets/js/dropzone-config-2.js
+++ b/public/assets/js/dropzone-config-2.js
@@ -9,6 +9,7 @@ Dropzone.options.realDropzone = {
     addRemoveLinks: true,
     dictRemoveFile: 'Remove',
     dictFileTooBig: 'Image is bigger than 8MB',
+    dictRemoveFileConfirmation: "Are you sure you wish to delete this image?",
 
     // The setting up of the dropzone
     init:function() {
@@ -16,7 +17,7 @@ Dropzone.options.realDropzone = {
         // Add server images
         var myDropzone = this;
 
-        $.get('/server-images', function(data) {
+        $.get('/dropzone-laravel-image-upload/public/server-images', function(data) {
 
             $.each(data.images, function (key, value) {
 
@@ -24,6 +25,7 @@ Dropzone.options.realDropzone = {
                 myDropzone.options.addedfile.call(myDropzone, file);
                 myDropzone.createThumbnailFromUrl(file, 'images/icon_size/' + value.server);
                 myDropzone.emit("complete", file);
+                $('.serverfilename', file.previewElement).val(value.server);
                 photo_counter++;
                 $("#photoCounter").text( "(" + photo_counter + ")");
             });
@@ -34,7 +36,7 @@ Dropzone.options.realDropzone = {
             $.ajax({
                 type: 'POST',
                 url: 'upload/delete',
-                data: {id: file.name, _token: $('#csrf-token').val()},
+                data: {id: $('.serverfilename', file.previewElement).val() , _token: $('#csrf-token').val()},
                 dataType: 'html',
                 success: function(data){
                     var rep = JSON.parse(data);
@@ -63,7 +65,8 @@ Dropzone.options.realDropzone = {
         }
         return _results;
     },
-    success: function(file,done) {
+    success: function(file,response) {
+        $('.serverfilename', file.previewElement).val(response.filename);
         photo_counter++;
         $("#photoCounter").text( "(" + photo_counter + ")");
     }

--- a/public/assets/js/dropzone-config-2.js
+++ b/public/assets/js/dropzone-config-2.js
@@ -17,7 +17,7 @@ Dropzone.options.realDropzone = {
         // Add server images
         var myDropzone = this;
 
-        $.get('/dropzone-laravel-image-upload/public/server-images', function(data) {
+        $.get('/server-images', function(data) {
 
             $.each(data.images, function (key, value) {
 

--- a/public/assets/js/dropzone-config-2.js
+++ b/public/assets/js/dropzone-config-2.js
@@ -22,7 +22,7 @@ Dropzone.options.realDropzone = {
 
                 var file = {name: value.original, size: value.size};
                 myDropzone.options.addedfile.call(myDropzone, file);
-                myDropzone.options.thumbnail.call(myDropzone, file, 'images/icon_size/' + value.server);
+    			myDropzone.createThumbnailFromUrl(file, 'images/icon_size/' + value.server);
                 myDropzone.emit("complete", file);
                 photo_counter++;
                 $("#photoCounter").text( "(" + photo_counter + ")");

--- a/resources/views/pages/upload-2.blade.php
+++ b/resources/views/pages/upload-2.blade.php
@@ -50,6 +50,7 @@
 
         <div class="dz-preview dz-file-preview">
             <div class="dz-image"><img data-dz-thumbnail=""></div>
+            <input type="hidden" class="serverfilename"/>
 
             <div class="dz-details">
                 <div class="dz-size"><span data-dz-size=""></span></div>


### PR DESCRIPTION
Use DropzoneJS createThumbnailFromUrl to show server uploaded images the same way as the new images. Add a confirmation alert before deleting an image. Delete images based on the filename created bu the server (will always be unique) rather than original filename, so that the correct images will be deleted.